### PR TITLE
Fixed deadlock and value recycling

### DIFF
--- a/avalanche.yaml
+++ b/avalanche.yaml
@@ -1,11 +1,7 @@
+componentCount: 50
 metricPrefix: "comp1"
-metricCount: 10       # number of unique metrics
-labelCount: 5         # labels per metric
+metricCount: 1000       # number of unique metrics
+labelCount: 100         # labels per metric
 valueInterval: 2      # values for metrics and labels refreshed every n seconds
-defaultCardinality: 1 # default if none is specified in the map below for a label
-
-# labels have the form "label_key_0, label_key_1 ... label_key_<labelCount>>"
-cardinalityMap:
-  label_key_0: 2    # Cardinality 2 for this label
-  label_key_1: 15   # Cardinality 15 for this label
-  label_key_2: 100  # Cardinality 100 for this label
+metricInterval: 100      # values for metrics and labels refreshed every n seconds
+defaultCardinality: 100


### PR DESCRIPTION
- Do not allocate generators for all labels
- Use of defer to unlock was incorrect
- Has to delete labels before entering new cycle
  (Upstream avalanche does that but we missed it)

Signed-off-by: JT <jt@kloudfuse.com>